### PR TITLE
Improved install routine

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The executable is stored in ~/aseprite. Have fun!
 
 ## How do I run Aseprite?
 This script automatically adds Aseprite to your desktop environment's application launcher and to $PATH.
-You can launch it in your desktop environment's application launcher or by entering "aseprite" in the terminal.
+You can launch it from your desktop environment's application launcher or by entering "aseprite" in the terminal.
 
 ## Credits
 I used [Aseprite's official compilation guide](https://github.com/aseprite/aseprite/blob/main/INSTALL.md) to make this script.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The executable is stored in ~/aseprite. Have fun!
 
 ## How do I run Aseprite?
 This script automatically adds Aseprite to your desktop environment's application launcher and to $PATH.
-You can launch it from your desktop environment's application launcher or by entering "aseprite" in the terminal.
+You can launch it from your desktop environment's application launcher or by entering `aseprite` in the terminal.
 
 ## Credits
 I used [Aseprite's official compilation guide](https://github.com/aseprite/aseprite/blob/main/INSTALL.md) to make this script.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Go to your downloads folder and open up a terminal window. Type in these command
 
 Please consider giving this repo a star if you found it helpful.
 
-If you encounter any errors, please report it in the issues tab.
+If you encounter any errors, please report them in the issues tab.
 
 ## Where is the executable?
 The executable is stored in ~/aseprite. Have fun!

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ Please consider giving this repo a star if you found it helpful.
 If you encounter any errors, please report it in the issues tab.
 
 ## Where is the executable?
-The executable is stored in ~/Applications/aseprite. Have fun!
+The executable is stored in $XDG_DATA_HOME/aseprite. Have fun!
 
-## Integrating with your desktop environment
-Download the aseprite.desktop file from this GitHub repository and move it to ~/.local/share/applications.
-Then, it should appear in your application menu!
+## How do I run Aseprite?
+This script should automatically add aseprite to your application menu and to your path.
+You should be able to launch it as you would any other software.
 
 ## Credits
 I condensed https://github.com/aseprite/aseprite/blob/main/INSTALL.md into this script.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Please consider giving this repo a star if you found it helpful.
 If you encounter any errors, please report it in the issues tab.
 
 ## Where is the executable?
-The executable is stored in $XDG_DATA_HOME/aseprite. Have fun!
+The executable is stored in ~/aseprite. Have fun!
 
 ## How do I run Aseprite?
 This script should automatically add aseprite to your application menu and to your path.

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ If you encounter any errors, please report it in the issues tab.
 The executable is stored in ~/aseprite. Have fun!
 
 ## How do I run Aseprite?
-This script should automatically add aseprite to your application menu and to your path.
-You should be able to launch it as you would any other software.
+This script automatically adds Aseprite to your desktop environment's application launcher and to $PATH.
+You can launch it in your desktop environment's application launcher or by entering "aseprite" in the terminal.
 
 ## Credits
 I condensed https://github.com/aseprite/aseprite/blob/main/INSTALL.md into this script.

--- a/aseprite.desktop
+++ b/aseprite.desktop
@@ -1,9 +1,0 @@
-[Desktop Entry]
-Name=Aseprite
-GenericName=Pixel Art Editor
-Exec=~/Applications/aseprite/aseprite
-Terminal=false
-Icon=~/Applications/aseprite/data/icons/ase256.png
-Type=Application
-Categories=Graphics
-StartupWMClass=aseprite

--- a/compile.sh
+++ b/compile.sh
@@ -57,36 +57,47 @@ fi
 
 # Install dependencies
 if [[ $package_man == "dnf" ]]; then
-  sudo dnf install -y gcc-c++ clang libcxx-devel cmake ninja-build libX11-devel libXcursor-devel libXi-devel mesa-libGL-devel fontconfig-devel git
+    sudo dnf install -y gcc-c++ clang libcxx-devel cmake ninja-build libX11-devel libXcursor-devel libXi-devel mesa-libGL-devel fontconfig-devel git
 elif [[ $package_man == "apt" ]]; then
-  sudo apt-get install -y g++ clang libc++-dev libc++abi-dev cmake ninja-build libx11-dev libxcursor-dev libxi-dev libgl1-mesa-dev libfontconfig1-dev git
+    sudo apt-get install -y g++ clang libc++-dev libc++abi-dev cmake ninja-build libx11-dev libxcursor-dev libxi-dev libgl1-mesa-dev libfontconfig1-dev git
 fi
 
+[[ $? == 0 ]] \
+    || { echo "failed to install dependencies" >&2 ; exit 1 ; }
+
 # Clone aseprite
-git clone --recursive https://github.com/aseprite/aseprite.git --depth=1
+git clone --recursive https://github.com/aseprite/aseprite.git --depth=1 \
+    || { echo "unable to clone code base" >&2 ; exit 1 ; }
 
 # Download skia
-wget https://github.com/aseprite/skia/releases/download/m102-861e4743af/Skia-Linux-Release-x64-libc++.zip
-mkdir ./skia
-unzip Skia-Linux-Release-x64-libc++.zip -d ./skia
+wget https://github.com/aseprite/skia/releases/download/m102-861e4743af/Skia-Linux-Release-x64-libc++.zip \
+    || { echo "failed to download skia" >&2 ; exit 1 ; }
+mkdir ./skia && unzip Skia-Linux-Release-x64-libc++.zip -d ./skia \
+    || { echo "failed to extract skia" >&2 ; exit 1 ; }
 
 echo "Finished downloading! Time to compile."
 
-mkdir aseprite/build
+mkdir aseprite/build \
+    || { echo "failed create build folder" >&2 ; exit 1 ; }
 pushd aseprite/build
+
 export CC=clang
 export CXX=clang++
 cmake \
-  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-  -DCMAKE_CXX_FLAGS:STRING=-stdlib=libc++ \
-  -DCMAKE_EXE_LINKER_FLAGS:STRING=-stdlib=libc++ \
-  -DLAF_BACKEND=skia \
-  -DSKIA_DIR="${WORK_DIR}/skia" \
-  -DSKIA_LIBRARY_DIR="${WORK_DIR}/skia/out/Release-x64" \
-  -DSKIA_LIBRARY="${WORK_DIR}/skia/out/Release-x64/libskia.a" \
-  -G Ninja \
-  ..
-ninja aseprite
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    -DCMAKE_CXX_FLAGS:STRING=-stdlib=libc++ \
+    -DCMAKE_EXE_LINKER_FLAGS:STRING=-stdlib=libc++ \
+    -DLAF_BACKEND=skia \
+    -DSKIA_DIR="${WORK_DIR}/skia" \
+    -DSKIA_LIBRARY_DIR="${WORK_DIR}/skia/out/Release-x64" \
+    -DSKIA_LIBRARY="${WORK_DIR}/skia/out/Release-x64/libskia.a" \
+    -G Ninja \
+    .. \
+    || { echo "configuration failed" >&2 ; exit 1 ; }
+
+ninja aseprite \
+    || { echo "compilation failed" >&2 ; exit 1 ; }
+
 popd
 
 rm -rf "${INSTALL_DIR}" \
@@ -94,12 +105,12 @@ rm -rf "${INSTALL_DIR}" \
 mkdir -p "${INSTALL_DIR}" "${BINARY_DIR}" "${LAUNCHER_DIR}" "${ICON_DIR}" \
     || { echo "unable to create install folder" >&2 ; exit 1 ; }
 
-mv aseprite/build/bin/* "${INSTALL_DIR}"
-
-touch "${SIGNATURE_FILE}"
-ln -s "${INSTALL_DIR}/aseprite" "${BINARY_FILE}"
-ln -s "${INSTALL_DIR}/data/icons/ase256.png" "${ICON_FILE}"
-cp "${WORK_DIR}/aseprite/src/desktop/linux/aseprite.desktop" "${LAUNCHER_FILE}"
+{ mv aseprite/build/bin/* "${INSTALL_DIR}" \
+    && touch "${SIGNATURE_FILE}" \
+    && ln -sf "${INSTALL_DIR}/aseprite" "${BINARY_FILE}" \
+    && ln -sf "${INSTALL_DIR}/data/icons/ase256.png" "${ICON_FILE}" \
+    && cp -f "${WORK_DIR}/aseprite/src/desktop/linux/aseprite.desktop" "${LAUNCHER_FILE}" \
+; } || { echo "failed to complete install" >&2 ; exit 1 ; }
 
 echo "Done compiling!"
 echo "The executable is stored in '${INSTALL_DIR}'. Have fun!"

--- a/compile.sh
+++ b/compile.sh
@@ -13,19 +13,19 @@ LAUNCHER_FILE="${LAUNCHER_DIR}/aseprite.desktop"
 ICON_FILE="${ICON_DIR}/aseprite.png"
 
 if [[ -f "${SIGNATURE_FILE}" ]] ; then
-    read -e -p "aseprite already installed. update? (y/n): " choice
+    read -e -p "Aseprite already installed. Update? (y/n): " choice
     [[ "${choice}" == [Yy]* ]] \
         || exit 0
 else
     [[ -d "${INSTALL_DIR}" ]] \
-        && { echo "aseprite already installed to '${INSTALL_DIR}'. aborting" >&2 ; exit 1 ; }
+        && { echo "Aseprite already installed to '${INSTALL_DIR}'. Aborting" >&2 ; exit 1 ; }
     { [[ -f "${LAUNCHER_FILE}" ]] || [[ -f "${BINARY_FILE}" ]] || [[ -f "${ICON_FILE}" ]] ; } \
-        && { echo "other aseprite data already installed to home directory. aborting" >&2 ; exit 1 ; }
+        && { echo "Other aseprite data already installed to home directory. Aborting" >&2 ; exit 1 ; }
 fi
 
 if [[ -z "${TESTING}" ]] ; then
     WORK_DIR=$(mktemp -d -t 'compile-aseprite-linux-XXXXX') \
-        || { echo "unable to create temp folder" >&2 ; exit 1 ; }
+        || { echo "Unable to create temp folder" >&2 ; exit 1 ; }
 else
     WORK_DIR='compile-aseprite-linux-testing'
     mkdir -p "${WORK_DIR}"
@@ -34,7 +34,7 @@ WORK_DIR="$(realpath "${WORK_DIR}")"
 
 cleanup() {
     code=$?
-    echo "cleaning up"
+    echo "Cleaning up."
     pushd -0 >/dev/null
     dirs -c
     if [[ -z "${TESTING}" ]] ; then
@@ -58,7 +58,7 @@ if [[ "$os_name" == *"Fedora"* ]]; then
 elif [[ $os_name == *"Debian"* ]] || [[ $os_name == *"Ubuntu"* ]] || [[ $os_name == *"Mint"* ]]; then
     package_man="apt"
 else
-    echo "Unsupported distro! If your distro supports APT or DNF, please manually set os_name='Ubuntu' for apt, or os_name='Fedora' at the top of the file. Copy the appropriate command and replace the 'os_name=' with the proper command. You can also open an issue ticket."
+    echo "Unsupported distro! If your distro supports APT or DNF, please manually modify the script to set os_name='Ubuntu' for apt, or os_name='Fedora'. You can also open an issue ticket."
     echo "Stopped installation!"
     exit 1
 fi
@@ -73,22 +73,22 @@ elif [[ $package_man == "apt" ]]; then
 fi
 
 [[ $? == 0 ]] \
-    || { echo "failed to install dependencies" >&2 ; exit 1 ; }
+    || { echo "Failed to install dependencies." >&2 ; exit 1 ; }
 
 # Clone aseprite
 git clone --recursive https://github.com/aseprite/aseprite.git --depth=1 \
-    || { echo "unable to clone code base" >&2 ; exit 1 ; }
+    || { echo "Unable to clone Aseprite repo." >&2 ; exit 1 ; }
 
 # Download skia
 wget -O skia.zip https://github.com/aseprite/skia/releases/download/m124-08a5439a6b/Skia-Linux-Release-x64.zip \
-    || { echo "failed to download skia" >&2 ; exit 1 ; }
+    || { echo "Failed to download skia." >&2 ; exit 1 ; }
 mkdir ./skia && unzip skia.zip -d ./skia \
-    || { echo "failed to extract skia" >&2 ; exit 1 ; }
+    || { echo "Failed to extract skia." >&2 ; exit 1 ; }
 
 echo "Finished downloading! Time to compile."
 
 mkdir aseprite/build \
-    || { echo "failed create build folder" >&2 ; exit 1 ; }
+    || { echo "Failed create build folder." >&2 ; exit 1 ; }
 pushd aseprite/build
 
 export CC=clang
@@ -103,24 +103,24 @@ cmake \
     -DSKIA_LIBRARY="${WORK_DIR}/skia/out/Release-x64/libskia.a" \
     -G Ninja \
     .. \
-    || { echo "configuration failed" >&2 ; exit 1 ; }
+    || { echo "Configuration failed." >&2 ; exit 1 ; }
 
 ninja aseprite \
-    || { echo "compilation failed" >&2 ; exit 1 ; }
+    || { echo "Compilation failed." >&2 ; exit 1 ; }
 
 popd
 
 rm -rf "${INSTALL_DIR}" \
-    || { echo "unable to clean up old install" >&2 ; exit 1 ; }
+    || { echo "Unable to clean up old install." >&2 ; exit 1 ; }
 mkdir -p "${INSTALL_DIR}" "${BINARY_DIR}" "${LAUNCHER_DIR}" "${ICON_DIR}" \
-    || { echo "unable to create install folder" >&2 ; exit 1 ; }
+    || { echo "Unable to create install folder." >&2 ; exit 1 ; }
 
 { mv aseprite/build/bin/* "${INSTALL_DIR}" \
     && touch "${SIGNATURE_FILE}" \
     && ln -sf "${INSTALL_DIR}/aseprite" "${BINARY_FILE}" \
     && ln -sf "${INSTALL_DIR}/data/icons/ase256.png" "${ICON_FILE}" \
     && cp -f "${WORK_DIR}/aseprite/src/desktop/linux/aseprite.desktop" "${LAUNCHER_FILE}" \
-; } || { echo "failed to complete install" >&2 ; exit 1 ; }
+; } || { echo "Failed to complete install." >&2 ; exit 1 ; }
 
 echo "Done compiling!"
 echo "The executable is stored in '${INSTALL_DIR}'. Have fun!"

--- a/compile.sh
+++ b/compile.sh
@@ -4,7 +4,7 @@
 
 INSTALL_DIR="${XDG_DATA_HOME}/aseprite"
 BINARY_DIR="${HOME}/.local/bin"
-LAUNCHER_DIR="${XDG_DATA_HOME}/.local/share/applications"
+LAUNCHER_DIR="${XDG_DATA_HOME}/applications"
 ICON_DIR="${XDG_DATA_HOME}/icons"
 
 SIGNATURE_FILE="${INSTALL_DIR}/compile-aseprite-linux"

--- a/compile.sh
+++ b/compile.sh
@@ -4,7 +4,7 @@
 
 INSTALL_DIR="${XDG_DATA_HOME}/aseprite"
 BINARY_DIR="${HOME}/.local/bin"
-LAUNCHER_DIR="${XDG_DATA_HOME}/applications"
+LAUNCHER_DIR="${XDG_DATA_HOME}/.local/share/applications"
 ICON_DIR="${XDG_DATA_HOME}/icons"
 
 SIGNATURE_FILE="${INSTALL_DIR}/compile-aseprite-linux"


### PR DESCRIPTION
This commit set contains a number of fixes and changes. I can split them into multiple pull requests if you'd like

Fixes:
- The deletion of temp folders 'deps' and 'aseprite' could result in loss of user data. This have been fixed by using a unique temp folder
- The script cleans up after itself, even if it exits early
- Any commands that touch the file system are checked for success, and will exit early if they fail. This addresses #4 

Changes:
- Moved the output folder to the location specified by XDG
- Added aseprite to the user's path for command line execution
- Script now automatically installs the official desktop file